### PR TITLE
Add MIT license and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Python caches
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Virtual environments
+venv/
+ENV/
+.env/
+*.env
+
+# IDE files
+.vscode/
+.idea/
+
+# Log files
+*.log
+
+# Python bytecode
+*.pyo
+*.pyd
+
+# Test / coverage files
+.coverage
+htmlcov/
+.coverage.*
+.pytest_cache/
+
+# Misc
+.DS_Store
+Thumbs.db
+known_nicks.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 pyircstats contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Supported formats include:
 
 ## License
 
-MIT
+This project is licensed under the [MIT License](LICENSE).
 
 ## Credits
 


### PR DESCRIPTION
## Summary
- add MIT license file
- update README to link to new license
- include Python-focused `.gitignore` to avoid committing build artifacts

## Testing
- `python -m py_compile ircstats.py`
- `python ircstats.py` *(fails: Usage: ircstats.py /path/to/logdir)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9a46db548329a610194fde89de66