### PR TITLE
Add Docker image workflows for develop and release

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -1,0 +1,27 @@
+name: Build and push Docker image (develop)
+
+on:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:develop
+

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,29 @@
+name: Build and push Docker image (release)
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . /app
+
+ENTRYPOINT ["python", "/app/ircstats.py"]
+CMD ["/logs"]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ This will:
 - Generate or update per-log JSON caches
 - Output a `index.html` file with aggregated stats
 
+## Docker
+
+Prebuilt images are available via GitHub Container Registry.
+
+### Latest release
+
+```bash
+docker pull ghcr.io/youruser/pyircstats:latest
+docker run --rm -v /path/to/logs:/logs ghcr.io/youruser/pyircstats:latest /logs
+```
+
+### Development build
+
+```bash
+docker pull ghcr.io/youruser/pyircstats:develop
+```
+
 ## File Structure
 
 Logs should be named as `YYYY-MM-DD.log`, e.g.:
@@ -65,7 +82,6 @@ Supported formats include:
 - Export CSV/JSON summaries
 - Per-user stat pages
 - Tagging known bots
-- Docker support
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add Dockerfile for building pyircstats container
- Publish develop and release images to GitHub Container Registry via GitHub Actions
- Document Docker usage in README

## Testing
- `python -m py_compile ircstats.py`
- `python ircstats.py .`
- `docker build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdadcf9f188329bc35d078ed346870